### PR TITLE
feat: replace screen-size-sensitive chart with a manual chart type and k value

### DIFF
--- a/src/i18n/message/app/dashboard-resource.json
+++ b/src/i18n/message/app/dashboard-resource.json
@@ -10,7 +10,7 @@
                 "chartType": {
                     "pie": "玫瑰图",
                     "bar": "条形图",
-                    "half-pie": "半环图"
+                    "halfPie": "半环图"
                 },
                 "k": {
                     "6": "前6位",
@@ -40,7 +40,7 @@
                 "chartType": {
                     "pie": "玫瑰圖",
                     "bar": "條形圖",
-                    "half-pie": "半環圖"
+                    "halfPie": "半環圖"
                 },
                 "k": {
                     "6": "前6位",
@@ -70,7 +70,7 @@
                 "chartType": {
                     "pie": "Nightingale",
                     "bar": "Bar",
-                    "half-pie": "Half Doughnut"
+                    "halfPie": "Half Doughnut"
                 },
                 "k": {
                     "6": "top 6",
@@ -95,19 +95,7 @@
             "title1": "過去 1 年間にオンラインで費やした時間は 1 時間未満"
         },
         "topK": {
-            "title": "過去 {day} 日間に最も拜訪された TOP {k}",
-            "filter": {
-                "chartType": {
-                    "pie": "",
-                    "bar": "",
-                    "half-pie": ""
-                },
-                "k": {
-                    "6": "",
-                    "8": "",
-                    "10": ""
-                }
-            }
+            "title": "過去 {day} 日間に最も拜訪された TOP {k}"
         },
         "indicator": {
             "installedDays": "使用 {number} 日",
@@ -125,19 +113,7 @@
             "title1": "Navegue por menos de 1 hora no ano passado"
         },
         "topK": {
-            "title": "TOP {k} mais visitados nos últimos {day} dias",
-            "filter": {
-                "chartType": {
-                    "pie": "",
-                    "bar": "",
-                    "half-pie": ""
-                },
-                "k": {
-                    "6": "",
-                    "8": "",
-                    "10": ""
-                }
-            }
+            "title": "TOP {k} mais visitados nos últimos {day} dias"
         },
         "indicator": {
             "installedDays": "Instalado por {number} dias",
@@ -155,19 +131,7 @@
             "title1": "Перегляд менш ніж 1 годину за минулий рік"
         },
         "topK": {
-            "title": "Найбільші {k} відвідувань за минулих {day} днів",
-            "filter": {
-                "chartType": {
-                    "pie": "",
-                    "bar": "",
-                    "half-pie": ""
-                },
-                "k": {
-                    "6": "",
-                    "8": "",
-                    "10": ""
-                }
-            }
+            "title": "Найбільші {k} відвідувань за минулих {day} днів"
         },
         "indicator": {
             "installedDays": "Встановлено впродовж {number} днів",
@@ -185,19 +149,7 @@
             "title1": "Navegó menos de 1 hora en el último año"
         },
         "topK": {
-            "title": "TOP {k} más visitado en los últimos {day} días",
-            "filter": {
-                "chartType": {
-                    "pie": "",
-                    "bar": "",
-                    "half-pie": ""
-                },
-                "k": {
-                    "6": "",
-                    "8": "",
-                    "10": ""
-                }
-            }
+            "title": "TOP {k} más visitado en los últimos {day} días"
         },
         "indicator": {
             "installedDays": "Instalado durante {number} días",
@@ -215,19 +167,7 @@
             "title1": "Durchsucht weniger als 1 Stunde im letzten Jahr"
         },
         "topK": {
-            "title": "TOP {k} am meisten besucht in den letzten {day} Tagen",
-            "filter": {
-                "chartType": {
-                    "pie": "",
-                    "bar": "",
-                    "half-pie": ""
-                },
-                "k": {
-                    "6": "",
-                    "8": "",
-                    "10": ""
-                }
-            }
+            "title": "TOP {k} am meisten besucht in den letzten {day} Tagen"
         },
         "indicator": {
             "installedDays": "Für {number} Tage installiert",
@@ -245,19 +185,7 @@
             "title1": "Parcouru moins d'une heure l'année dernière"
         },
         "topK": {
-            "title": "Top {k} des sites les plus visités les {day} derniers jours",
-            "filter": {
-                "chartType": {
-                    "pie": "",
-                    "bar": "",
-                    "half-pie": ""
-                },
-                "k": {
-                    "6": "",
-                    "8": "",
-                    "10": ""
-                }
-            }
+            "title": "Top {k} des sites les plus visités les {day} derniers jours"
         },
         "indicator": {
             "installedDays": "Installé depuis {number} jours",
@@ -275,19 +203,7 @@
             "title1": "За последний год просмотрено менее 1 часа"
         },
         "topK": {
-            "title": "ТОП-{k} самых посещаемых сайтов за последние {day} дней",
-            "filter": {
-                "chartType": {
-                    "pie": "",
-                    "bar": "",
-                    "half-pie": ""
-                },
-                "k": {
-                    "6": "",
-                    "8": "",
-                    "10": ""
-                }
-            }
+            "title": "ТОП-{k} самых посещаемых сайтов за последние {day} дней"
         },
         "indicator": {
             "installedDays": "Прошло дней с установки: {number}",
@@ -305,19 +221,7 @@
             "title1": "تم التصفح أقل من ساعة في العام الماضي"
         },
         "topK": {
-            "title": "أفضل {k} مواقع الأكثر زيارة خلال الـ {day} يوم الماضية",
-            "filter": {
-                "chartType": {
-                    "pie": "",
-                    "bar": "",
-                    "half-pie": ""
-                },
-                "k": {
-                    "6": "",
-                    "8": "",
-                    "10": ""
-                }
-            }
+            "title": "أفضل {k} مواقع الأكثر زيارة خلال الـ {day} يوم الماضية"
         },
         "indicator": {
             "installedDays": "تم التثبيت لمدة {number} أيام",

--- a/src/i18n/message/app/dashboard-resource.json
+++ b/src/i18n/message/app/dashboard-resource.json
@@ -5,7 +5,19 @@
             "title1": "近一年上网总时长不足 1 小时"
         },
         "topK": {
-            "title": "近 {day} 天最常访问 TOP {k}"
+            "title": "近 {day} 天最常访问 TOP {k}",
+            "filter": {
+                "chartType": {
+                    "pie": "玫瑰图",
+                    "bar": "条形图",
+                    "half-pie": "半环图"
+                },
+                "k": {
+                    "6": "前6位",
+                    "8": "前8位",
+                    "10": "前10位"
+                }
+            }
         },
         "indicator": {
             "installedDays": "已使用 {number} 天",
@@ -23,7 +35,19 @@
             "title1": "近一年瀏覽時數少於 1 小時"
         },
         "topK": {
-            "title": "近 {day} 天最常造訪 TOP {k}"
+            "title": "近 {day} 天最常造訪 TOP {k}",
+            "filter": {
+                "chartType": {
+                    "pie": "玫瑰圖",
+                    "bar": "條形圖",
+                    "half-pie": "半環圖"
+                },
+                "k": {
+                    "6": "前6位",
+                    "8": "前8位",
+                    "10": "前10位"
+                }
+            }
         },
         "indicator": {
             "installedDays": "已使用 {number} 天",
@@ -41,7 +65,19 @@
             "title1": "Browsed less than 1 hour last year"
         },
         "topK": {
-            "title": "TOP {k} most visited in the past {day} days"
+            "title": "TOP {k} most visited in the past {day} days",
+            "filter": {
+                "chartType": {
+                    "pie": "Nightingale",
+                    "bar": "Bar",
+                    "half-pie": "Half Doughnut"
+                },
+                "k": {
+                    "6": "top 6",
+                    "8": "top 8",
+                    "10": "top 10"
+                }
+            }
         },
         "indicator": {
             "installedDays": "Installed for {number} days",
@@ -59,7 +95,19 @@
             "title1": "過去 1 年間にオンラインで費やした時間は 1 時間未満"
         },
         "topK": {
-            "title": "過去 {day} 日間に最も拜訪された TOP {k}"
+            "title": "過去 {day} 日間に最も拜訪された TOP {k}",
+            "filter": {
+                "chartType": {
+                    "pie": "",
+                    "bar": "",
+                    "half-pie": ""
+                },
+                "k": {
+                    "6": "",
+                    "8": "",
+                    "10": ""
+                }
+            }
         },
         "indicator": {
             "installedDays": "使用 {number} 日",
@@ -77,7 +125,19 @@
             "title1": "Navegue por menos de 1 hora no ano passado"
         },
         "topK": {
-            "title": "TOP {k} mais visitados nos últimos {day} dias"
+            "title": "TOP {k} mais visitados nos últimos {day} dias",
+            "filter": {
+                "chartType": {
+                    "pie": "",
+                    "bar": "",
+                    "half-pie": ""
+                },
+                "k": {
+                    "6": "",
+                    "8": "",
+                    "10": ""
+                }
+            }
         },
         "indicator": {
             "installedDays": "Instalado por {number} dias",
@@ -95,7 +155,19 @@
             "title1": "Перегляд менш ніж 1 годину за минулий рік"
         },
         "topK": {
-            "title": "Найбільші {k} відвідувань за минулих {day} днів"
+            "title": "Найбільші {k} відвідувань за минулих {day} днів",
+            "filter": {
+                "chartType": {
+                    "pie": "",
+                    "bar": "",
+                    "half-pie": ""
+                },
+                "k": {
+                    "6": "",
+                    "8": "",
+                    "10": ""
+                }
+            }
         },
         "indicator": {
             "installedDays": "Встановлено впродовж {number} днів",
@@ -113,7 +185,19 @@
             "title1": "Navegó menos de 1 hora en el último año"
         },
         "topK": {
-            "title": "TOP {k} más visitado en los últimos {day} días"
+            "title": "TOP {k} más visitado en los últimos {day} días",
+            "filter": {
+                "chartType": {
+                    "pie": "",
+                    "bar": "",
+                    "half-pie": ""
+                },
+                "k": {
+                    "6": "",
+                    "8": "",
+                    "10": ""
+                }
+            }
         },
         "indicator": {
             "installedDays": "Instalado durante {number} días",
@@ -131,7 +215,19 @@
             "title1": "Durchsucht weniger als 1 Stunde im letzten Jahr"
         },
         "topK": {
-            "title": "TOP {k} am meisten besucht in den letzten {day} Tagen"
+            "title": "TOP {k} am meisten besucht in den letzten {day} Tagen",
+            "filter": {
+                "chartType": {
+                    "pie": "",
+                    "bar": "",
+                    "half-pie": ""
+                },
+                "k": {
+                    "6": "",
+                    "8": "",
+                    "10": ""
+                }
+            }
         },
         "indicator": {
             "installedDays": "Für {number} Tage installiert",
@@ -149,7 +245,19 @@
             "title1": "Parcouru moins d'une heure l'année dernière"
         },
         "topK": {
-            "title": "Top {k} des sites les plus visités les {day} derniers jours"
+            "title": "Top {k} des sites les plus visités les {day} derniers jours",
+            "filter": {
+                "chartType": {
+                    "pie": "",
+                    "bar": "",
+                    "half-pie": ""
+                },
+                "k": {
+                    "6": "",
+                    "8": "",
+                    "10": ""
+                }
+            }
         },
         "indicator": {
             "installedDays": "Installé depuis {number} jours",
@@ -167,7 +275,19 @@
             "title1": "За последний год просмотрено менее 1 часа"
         },
         "topK": {
-            "title": "ТОП-{k} самых посещаемых сайтов за последние {day} дней"
+            "title": "ТОП-{k} самых посещаемых сайтов за последние {day} дней",
+            "filter": {
+                "chartType": {
+                    "pie": "",
+                    "bar": "",
+                    "half-pie": ""
+                },
+                "k": {
+                    "6": "",
+                    "8": "",
+                    "10": ""
+                }
+            }
         },
         "indicator": {
             "installedDays": "Прошло дней с установки: {number}",
@@ -185,7 +305,19 @@
             "title1": "تم التصفح أقل من ساعة في العام الماضي"
         },
         "topK": {
-            "title": "أفضل {k} مواقع الأكثر زيارة خلال الـ {day} يوم الماضية"
+            "title": "أفضل {k} مواقع الأكثر زيارة خلال الـ {day} يوم الماضية",
+            "filter": {
+                "chartType": {
+                    "pie": "",
+                    "bar": "",
+                    "half-pie": ""
+                },
+                "k": {
+                    "6": "",
+                    "8": "",
+                    "10": ""
+                }
+            }
         },
         "indicator": {
             "installedDays": "تم التثبيت لمدة {number} أيام",

--- a/src/i18n/message/app/dashboard.ts
+++ b/src/i18n/message/app/dashboard.ts
@@ -14,6 +14,14 @@ export type DashboardMessage = {
     },
     topK: {
         title: string
+        filter: {
+            chartType: {
+                [key: string]: string
+            }
+            k: {
+                [key: string]: string
+            }
+        }
     }
     indicator: {
         installedDays: string

--- a/src/pages/app/components/Dashboard/components/TopKVisit/BarChart/Wrapper.ts
+++ b/src/pages/app/components/Dashboard/components/TopKVisit/BarChart/Wrapper.ts
@@ -1,0 +1,100 @@
+import type {ComposeOption} from "echarts/core";
+import type {BarSeriesOption} from "echarts/charts";
+import { EchartsWrapper } from "@hooks/useEcharts"
+import type {GridComponentOption, TooltipComponentOption} from "echarts/components";
+import {BizOption} from "../context";
+import {generateSiteLabel} from "@util/site";
+import { getStepColors, tooltipDot } from "@app/util/echarts";
+
+type EcOption = ComposeOption<
+    | BarSeriesOption
+    | GridComponentOption
+    | TooltipComponentOption
+>
+
+const tooltipOption = (): EcOption['tooltip'] => (
+    {
+        show: true,
+        borderWidth: 0,
+        formatter(params: any) {
+            const color = params?.color || "#000"
+            const point = tooltipDot(color)
+            const visit = params.data?.value || 0
+            const host = params.data?.host || ''
+            const alias = params.data?.alias || ''
+            const hostLabel = generateSiteLabel(host, alias)
+            return `${point} ${hostLabel}<br/><b>${visit}</b>`
+        }
+    }
+)
+
+const generateOption = (data: BizOption[], domWidth: number): EcOption => {
+    data = data?.sort((a, b) => (b?.value ?? 0) - (a?.value ?? 0))
+    const max = Math.max(...(data?.map(v => v.value) || []))
+    const hosts = data?.sort((a, b) => (a.value ?? 0) - (b?.value ?? 0))?.map(v => v.host) || []
+    const margin = 8
+    const chartW = domWidth * (100 - margin * 2) / 100
+    return {
+        tooltip: tooltipOption(),
+        grid: { left: '5%', right: '5%', bottom: '3%', top: '8%', },
+        xAxis: {
+            type: "value",
+            minInterval: 1,
+            axisLabel: { show: false },
+            splitLine: { show: false },
+            min: 0,
+            max: max,
+        },
+        yAxis: {
+            type: "category",
+            data: hosts,
+            axisLabel: { show: false },
+            axisTick: { show: false },
+            axisLine: { show: false },
+        },
+        series: {
+            type: "bar",
+            barWidth: '100%',
+            data: data.map((row, idx) => {
+                const isBottom = idx === 0
+                const isTop = idx === data.length - 1
+                const { value = 0 } = row || {}
+                const labelW = (value / max) * chartW - 8
+                return {
+                    ...row,
+                    label: { show: labelW >= 50, width: labelW },
+                    itemStyle: {
+                        borderRadius: [
+                            isTop ? 5 : 0, isTop ? 5 : 0, 5, isBottom ? 5 : 0
+                        ]
+                    },
+                }
+            }),
+            label: {
+                position: 'insideRight',
+                overflow: "truncate",
+                ellipsis: '...',
+                minMargin: 5,
+                padding: [0, 4, 0, 0],
+                formatter: (param: any) => {
+                    const { host, name } = (param?.data || {})
+                    return name || host
+                },
+            },
+            colorBy: 'data',
+            color: getStepColors(data.length, 1.5),
+        },
+    }
+}
+
+class Wrapper extends EchartsWrapper<BizOption[], EcOption> {
+    protected isSizeSensitize: boolean = true
+    generateOption = (option: BizOption[]) => {
+        if (!option?.length) return {}
+        const domWidth = this.getDomWidth()
+        if (!domWidth) return {}
+        return generateOption(option, domWidth)
+    }
+}
+
+export default Wrapper

--- a/src/pages/app/components/Dashboard/components/TopKVisit/BarChart/index.tsx
+++ b/src/pages/app/components/Dashboard/components/TopKVisit/BarChart/index.tsx
@@ -1,0 +1,17 @@
+import { useEcharts } from "@hooks/useEcharts"
+import { computed, defineComponent, type StyleValue } from "vue"
+import { useTopKFilter, useTopKValue } from "../context"
+import Wrapper from "./Wrapper"
+
+const CONTAINER_STYLE: StyleValue = {
+    width: "100%",
+    height: "220%",
+}
+
+const _default = defineComponent(() => {
+    const value = useTopKValue()
+    const { elRef } = useEcharts(Wrapper, value, { manual: true })
+    return () => <div style={CONTAINER_STYLE} ref={elRef} />
+})
+
+export default _default

--- a/src/pages/app/components/Dashboard/components/TopKVisit/Filter.tsx
+++ b/src/pages/app/components/Dashboard/components/TopKVisit/Filter.tsx
@@ -2,7 +2,7 @@ import { defineComponent } from 'vue'
 import { type ChartType } from './common'
 import { useTopKFilter } from './context'
 import SelectFilterItem from "@app/components/common/filter/SelectFilterItem";
-import {ElRadioButton, ElRadioGroup} from "element-plus";
+import {ElCheckboxGroup, ElRadioButton, ElRadioGroup} from "element-plus";
 import {t} from "@app/locale";
 
 type _SizeOption = [number, string]
@@ -23,7 +23,7 @@ function allOptions(): Record<number, string> {
 const CHART_CONFIG: { [type in ChartType]: string } = {
     'pie': t(msg => msg.dashboard.topK.filter.chartType['pie']),
     'bar': t(msg => msg.dashboard.topK.filter.chartType['bar']),
-    'half-pie': t(msg => msg.dashboard.topK.filter.chartType['half-pie']),
+    'halfPie': t(msg => msg.dashboard.topK.filter.chartType['halfPie']),
 }
 
 const _default = defineComponent(() => {

--- a/src/pages/app/components/Dashboard/components/TopKVisit/Filter.tsx
+++ b/src/pages/app/components/Dashboard/components/TopKVisit/Filter.tsx
@@ -1,5 +1,5 @@
 import { defineComponent } from 'vue'
-import { type ChartType } from './common'
+import {type TopKChartType} from './common'
 import { useTopKFilter } from './context'
 import SelectFilterItem from "@app/components/common/filter/SelectFilterItem";
 import {ElCheckboxGroup, ElRadioButton, ElRadioGroup} from "element-plus";
@@ -20,32 +20,37 @@ function allOptions(): Record<number, string> {
     return allOptions
 }
 
-const CHART_CONFIG: { [type in ChartType]: string } = {
+const CHART_CONFIG: { [type in TopKChartType]: string } = {
     'pie': t(msg => msg.dashboard.topK.filter.chartType['pie']),
     'bar': t(msg => msg.dashboard.topK.filter.chartType['bar']),
     'halfPie': t(msg => msg.dashboard.topK.filter.chartType['halfPie']),
 }
 
 const _default = defineComponent(() => {
-    const filter = useTopKFilter()
+    const topKFilter = useTopKFilter()
 
     return () => (
         <div class="filter">
             <SelectFilterItem
                 historyName='topK'
-                defaultValue={filter.topK?.toString?.()}
+                defaultValue={topKFilter.topK?.toString?.()}
                 options={allOptions()}
                 onSelect={val => {
                     if (!val) return
                     const newTopK = parseInt(val)
                     if (isNaN(newTopK)) return
-                    filter.topK = newTopK
+                    topKFilter.topK = newTopK
                 }}
                 style={{width: "30%"}}
             />
             <ElRadioGroup
-                modelValue={filter.chartType}
-                onChange={val => val && (filter.chartType = val as ChartType)}
+                modelValue={topKFilter.topKChartType}
+                onChange={val => {
+                    if (val === undefined) return
+                    if (val === 'pie' || val === 'bar' || val === 'halfPie') {
+                        topKFilter.topKChartType = val as TopKChartType
+                    }
+                }}
             >
                 {Object.entries(CHART_CONFIG).map(([type, name]) => (
                     <ElRadioButton value={type}>

--- a/src/pages/app/components/Dashboard/components/TopKVisit/Filter.tsx
+++ b/src/pages/app/components/Dashboard/components/TopKVisit/Filter.tsx
@@ -1,0 +1,60 @@
+import { defineComponent } from 'vue'
+import { type ChartType } from './common'
+import { useTopKFilter } from './context'
+import SelectFilterItem from "@app/components/common/filter/SelectFilterItem";
+import {ElRadioButton, ElRadioGroup} from "element-plus";
+import {t} from "@app/locale";
+
+type _SizeOption = [number, string]
+
+function allOptions(): Record<number, string> {
+    const allOptions: Record<number, string> = {}
+    const allSizes: _SizeOption[] = [
+        [6, "6"],
+        [8, "8"],
+        [10, "10"],
+    ]
+    allSizes.forEach(
+        ([size, topk]) => (allOptions[size] = t(msg => msg.dashboard.topK.filter.k[topk]))
+    )
+    return allOptions
+}
+
+const CHART_CONFIG: { [type in ChartType]: string } = {
+    'pie': t(msg => msg.dashboard.topK.filter.chartType['pie']),
+    'bar': t(msg => msg.dashboard.topK.filter.chartType['bar']),
+    'half-pie': t(msg => msg.dashboard.topK.filter.chartType['half-pie']),
+}
+
+const _default = defineComponent(() => {
+    const filter = useTopKFilter()
+
+    return () => (
+        <div class="filter">
+            <SelectFilterItem
+                historyName='topK'
+                defaultValue={filter.topK?.toString?.()}
+                options={allOptions()}
+                onSelect={val => {
+                    if (!val) return
+                    const newTopK = parseInt(val)
+                    if (isNaN(newTopK)) return
+                    filter.topK = newTopK
+                }}
+                style={{width: "30%"}}
+            />
+            <ElRadioGroup
+                modelValue={filter.chartType}
+                onChange={val => val && (filter.chartType = val as ChartType)}
+            >
+                {Object.entries(CHART_CONFIG).map(([type, name]) => (
+                    <ElRadioButton value={type}>
+                        {name}
+                    </ElRadioButton>
+                ))}
+            </ElRadioGroup>
+        </div>
+    )
+})
+
+export default _default

--- a/src/pages/app/components/Dashboard/components/TopKVisit/HalfBarChart/Wrapper.ts
+++ b/src/pages/app/components/Dashboard/components/TopKVisit/HalfBarChart/Wrapper.ts
@@ -1,0 +1,64 @@
+import {getSeriesPalette, tooltipDot} from "@app/util/echarts"
+import { EchartsWrapper } from "@hooks/useEcharts"
+import { getPrimaryTextColor } from "@pages/util/style"
+import {
+    type PieSeriesOption,
+    type ComposeOption,
+    type GridComponentOption, type TooltipComponentOption, type BarSeriesOption
+} from "echarts"
+import { BizOption } from "../context"
+import {generateSiteLabel} from "@util/site";
+
+type EcOption = ComposeOption<
+    | PieSeriesOption
+    | GridComponentOption
+    | TooltipComponentOption
+>
+
+const tooltipOption = (): EcOption['tooltip'] => (
+    {
+        show: true,
+        borderWidth: 0,
+        formatter(params: any) {
+            const color = params?.color || "#000"
+            const point = tooltipDot(color)
+            const visit = params.data?.value || 0
+            const host = params.data?.host || ''
+            const alias = params.data?.alias || ''
+            const hostLabel = generateSiteLabel(host, alias)
+            return `${point} ${hostLabel}<br/><b>${visit}</b>`
+        }
+    }
+)
+
+const generateOption = (data: BizOption[]): EcOption => {
+    const textColor = getPrimaryTextColor()
+    return {
+        tooltip: tooltipOption(),
+        series: {
+            top: '10%',
+            height: '90%',
+            name: 'TopK',
+            type: 'pie',
+            radius: ['60%', '130%'],
+            center: ['50%', '80%'],
+            startAngle: 180,
+            endAngle: 360,
+            color: getSeriesPalette(),
+            label: { color: textColor },
+            data: data,
+        }
+    }
+}
+
+class Wrapper extends EchartsWrapper<BizOption[], EcOption> {
+    protected isSizeSensitize: boolean = true
+    generateOption = (option: BizOption[]) => {
+        if (!option?.length) return {}
+        const domWidth = this.getDomWidth()
+        if (!domWidth) return {}
+        return generateOption(option)
+    }
+}
+
+export default  Wrapper

--- a/src/pages/app/components/Dashboard/components/TopKVisit/HalfBarChart/index.tsx
+++ b/src/pages/app/components/Dashboard/components/TopKVisit/HalfBarChart/index.tsx
@@ -1,0 +1,17 @@
+import { useEcharts } from "@hooks/useEcharts"
+import { defineComponent, type StyleValue } from "vue"
+import { useTopKFilter, useTopKValue } from "../context"
+import Wrapper from "./Wrapper"
+
+const CONTAINER_STYLE: StyleValue = {
+    width: "100%",
+    height: "220%",
+}
+
+const _default = defineComponent(() => {
+    const value = useTopKValue()
+    const { elRef } = useEcharts(Wrapper, value, { manual: true })
+    return () => <div style={CONTAINER_STYLE} ref={elRef} />
+})
+
+export default _default

--- a/src/pages/app/components/Dashboard/components/TopKVisit/PieChart/Wrapper.ts
+++ b/src/pages/app/components/Dashboard/components/TopKVisit/PieChart/Wrapper.ts
@@ -1,0 +1,66 @@
+import {getSeriesPalette, tooltipDot} from "@app/util/echarts"
+import { EchartsWrapper } from "@hooks/useEcharts"
+import { getPrimaryTextColor } from "@pages/util/style"
+import {
+    type PieSeriesOption,
+    type ComposeOption,
+    type GridComponentOption, type TooltipComponentOption, type BarSeriesOption
+} from "echarts"
+import { BizOption } from "../context"
+import {generateSiteLabel} from "@util/site";
+
+type EcOption = ComposeOption<
+    | PieSeriesOption
+    | GridComponentOption
+    | TooltipComponentOption
+>
+
+const tooltipOption = (): EcOption['tooltip'] => (
+    {
+        show: true,
+        borderWidth: 0,
+        formatter(params: any) {
+            const color = params?.color || "#000"
+            const point = tooltipDot(color)
+            const visit = params.data?.value || 0
+            const host = params.data?.host || ''
+            const alias = params.data?.alias || ''
+            const hostLabel = generateSiteLabel(host, alias)
+            return `${point} ${hostLabel}<br/><b>${visit}</b>`
+        }
+    }
+)
+
+const generateOption = (data: BizOption[]): EcOption => {
+    const textColor = getPrimaryTextColor()
+    return {
+        tooltip: tooltipOption(),
+        series: {
+            top: '10%',
+            height: '90%',
+            name: 'TopK',
+            type: 'pie',
+            radius: [20, 80],
+            center: ['50%', '50%'],
+            roseType: 'area',
+            color: getSeriesPalette(),
+            itemStyle: {
+                borderRadius: 7,
+            },
+            label: { color: textColor },
+            data: data,
+        }
+    }
+}
+
+class Wrapper extends EchartsWrapper<BizOption[], EcOption> {
+    protected isSizeSensitize: boolean = true
+    generateOption = (option: BizOption[]) => {
+        if (!option?.length) return {}
+        const domWidth = this.getDomWidth()
+        if (!domWidth) return {}
+        return generateOption(option)
+    }
+}
+
+export default Wrapper

--- a/src/pages/app/components/Dashboard/components/TopKVisit/PieChart/index.tsx
+++ b/src/pages/app/components/Dashboard/components/TopKVisit/PieChart/index.tsx
@@ -1,0 +1,17 @@
+import { useEcharts } from "@hooks/useEcharts"
+import { defineComponent, type StyleValue } from "vue"
+import { useTopKFilter, useTopKValue } from "../context"
+import Wrapper from "./Wrapper"
+
+const CONTAINER_STYLE: StyleValue = {
+    width: "100%",
+    height: "220%",
+}
+
+const _default = defineComponent(() => {
+    const value = useTopKValue()
+    const { elRef } = useEcharts(Wrapper, value, { manual: true })
+    return () => <div style={CONTAINER_STYLE} ref={elRef} />
+})
+
+export default _default

--- a/src/pages/app/components/Dashboard/components/TopKVisit/common.ts
+++ b/src/pages/app/components/Dashboard/components/TopKVisit/common.ts
@@ -1,0 +1,19 @@
+import { t } from "@app/locale"
+import { type GridComponentOption } from "echarts/components"
+
+export const generateGridOption = (): GridComponentOption => {
+    return {
+        top: 30,
+        bottom: 40,
+        left: 40,
+        right: 20,
+    }
+}
+
+export type ChartType = 'bar' | 'pie' | 'half-pie'
+
+export type FilterOption = {
+    topK: number
+    chartType: ChartType
+}
+

--- a/src/pages/app/components/Dashboard/components/TopKVisit/common.ts
+++ b/src/pages/app/components/Dashboard/components/TopKVisit/common.ts
@@ -1,4 +1,3 @@
-import { t } from "@app/locale"
 import { type GridComponentOption } from "echarts/components"
 
 export const generateGridOption = (): GridComponentOption => {
@@ -10,7 +9,7 @@ export const generateGridOption = (): GridComponentOption => {
     }
 }
 
-export type ChartType = 'bar' | 'pie' | 'half-pie'
+export type ChartType = 'bar' | 'pie' | 'halfPie'
 
 export type FilterOption = {
     topK: number

--- a/src/pages/app/components/Dashboard/components/TopKVisit/common.ts
+++ b/src/pages/app/components/Dashboard/components/TopKVisit/common.ts
@@ -9,10 +9,10 @@ export const generateGridOption = (): GridComponentOption => {
     }
 }
 
-export type ChartType = 'bar' | 'pie' | 'halfPie'
+export type TopKChartType = 'bar' | 'pie' | 'halfPie'
 
 export type FilterOption = {
     topK: number
-    chartType: ChartType
+    topKChartType: TopKChartType
 }
 

--- a/src/pages/app/components/Dashboard/components/TopKVisit/context.ts
+++ b/src/pages/app/components/Dashboard/components/TopKVisit/context.ts
@@ -1,0 +1,62 @@
+import { useLocalStorage, useProvide, useProvider, useRequest } from "@hooks"
+import { computed, reactive, toRaw, watch, type Reactive, type Ref } from "vue"
+import type { FilterOption } from "./common"
+import statService, { type StatQueryParam } from "@service/stat-service"
+import { MILL_PER_DAY } from "@util/time";
+
+export type BizOption = {
+    name: string
+    value: number
+    // Extensive info
+    host: string
+    alias?: string
+}
+
+type Context = {
+    value: Ref<BizOption[]>
+    filter: Reactive<FilterOption>
+}
+
+const NAMESPACE = 'dashboardTopKVisit'
+const DAY_NUM = 30
+
+export const initProvider = () => {
+    const [cachedFilter, setFilterCache] = useLocalStorage<FilterOption>(
+        'habit_period_filter', { topK: 6, chartType: 'pie' }
+    )
+    const filter = reactive<FilterOption>(cachedFilter)
+    watch(() => filter, () => setFilterCache(toRaw(filter)), { deep: true })
+    const { data: value } = useRequest(async () => {
+        const now = new Date()
+        const startTime: Date = new Date(now.getTime() - MILL_PER_DAY * DAY_NUM)
+        const query: StatQueryParam = {
+            date: [startTime, now],
+            sort: "time",
+            sortOrder: 'DESC',
+            mergeDate: true,
+        }
+        const SIZE = filter.topK
+        const top = (await statService.selectByPage(query, { num: 1, size: SIZE })).list
+        const data: BizOption[] = top.map(({ time, siteKey, alias }) => ({
+            name: alias ?? siteKey?.host ?? '',
+            host: siteKey?.host ?? '',
+            alias,
+            value: time,
+        }))
+        for (let realSize = top.length; realSize < SIZE; realSize++) {
+            data.push({ name: '', host: '', value: 0 })
+        }
+        return data
+    }, {
+        deps: [() => filter.topK, () => filter.chartType],
+        defaultValue: []
+    })
+
+    useProvide<Context>(NAMESPACE, { value, filter });
+
+    return filter
+}
+
+export const useTopKValue = () => useProvider<Context, 'value'>(NAMESPACE, "value").value
+
+export const useTopKFilter = () => useProvider<Context, 'filter'>(NAMESPACE, "filter").filter

--- a/src/pages/app/components/Dashboard/components/TopKVisit/context.ts
+++ b/src/pages/app/components/Dashboard/components/TopKVisit/context.ts
@@ -22,7 +22,7 @@ const DAY_NUM = 30
 
 export const initProvider = () => {
     const [cachedFilter, setFilterCache] = useLocalStorage<FilterOption>(
-        'habit_period_filter', { topK: 6, chartType: 'pie' }
+        'habit_period_filter', { topK: 6, topKChartType: 'pie' }
     )
     const filter = reactive<FilterOption>(cachedFilter)
     watch(() => filter, () => setFilterCache(toRaw(filter)), { deep: true })
@@ -48,7 +48,7 @@ export const initProvider = () => {
         }
         return data
     }, {
-        deps: [() => filter.topK, () => filter.chartType],
+        deps: [() => filter.topK, () => filter.topKChartType],
         defaultValue: []
     })
 

--- a/src/pages/app/components/Dashboard/components/TopKVisit/index.tsx
+++ b/src/pages/app/components/Dashboard/components/TopKVisit/index.tsx
@@ -5,7 +5,6 @@
  * https://opensource.org/licenses/MIT
  */
 import { t } from "@app/locale"
-import { useEcharts } from "@hooks/useEcharts"
 import statService, { type StatQueryParam } from "@service/stat-service"
 import { MILL_PER_DAY } from "@util/time"
 import { defineComponent } from "vue"
@@ -50,7 +49,7 @@ const _default = defineComponent(() => {
                 <div class="chart-container">
                     {filter.chartType === 'pie' && <PieChart />}
                     {filter.chartType === 'bar' && <BarChart />}
-                    {filter.chartType === 'half-pie' && <HalfBarChart />}
+                    {filter.chartType === 'halfPie' && <HalfBarChart />}
                 </div>
             </div>
         )

--- a/src/pages/app/components/Dashboard/components/TopKVisit/index.tsx
+++ b/src/pages/app/components/Dashboard/components/TopKVisit/index.tsx
@@ -47,9 +47,9 @@ const _default = defineComponent(() => {
                 <ChartTitle text={title} />
                 <Filter />
                 <div class="chart-container">
-                    {filter.chartType === 'pie' && <PieChart />}
-                    {filter.chartType === 'bar' && <BarChart />}
-                    {filter.chartType === 'halfPie' && <HalfBarChart />}
+                    {filter.topKChartType === 'pie' && <PieChart />}
+                    {filter.topKChartType === 'bar' && <BarChart />}
+                    {filter.topKChartType === 'halfPie' && <HalfBarChart />}
                 </div>
             </div>
         )

--- a/src/pages/app/components/Dashboard/components/TopKVisit/index.tsx
+++ b/src/pages/app/components/Dashboard/components/TopKVisit/index.tsx
@@ -11,6 +11,11 @@ import { MILL_PER_DAY } from "@util/time"
 import { defineComponent } from "vue"
 import ChartTitle from "../../ChartTitle"
 import Wrapper, { type BizOption, DAY_NUM, TOP_NUM } from "./Wrapper"
+import { initProvider } from "./context"
+import Filter from "./Filter";
+import PieChart from "./PieChart";
+import BarChart from "./BarChart";
+import HalfBarChart from "./HalfBarChart";
 
 const fetchData = async () => {
     const now = new Date()
@@ -35,14 +40,21 @@ const fetchData = async () => {
 }
 
 const _default = defineComponent(() => {
-    const { elRef } = useEcharts(Wrapper, fetchData)
-    const title = t(msg => msg.dashboard.topK.title, { k: TOP_NUM, day: DAY_NUM })
-    return () => (
-        <div class="top-visit-container">
-            <ChartTitle text={title} />
-            <div style={{ flex: 1 }} ref={elRef} />
-        </div>
-    )
+    const filter = initProvider()
+    return () => {
+        const title = t(msg => msg.dashboard.topK.title, { k: filter.topK, day: DAY_NUM })
+        return (
+            <div class="top-visit-container">
+                <ChartTitle text={title} />
+                <Filter />
+                <div class="chart-container">
+                    {filter.chartType === 'pie' && <PieChart />}
+                    {filter.chartType === 'bar' && <BarChart />}
+                    {filter.chartType === 'half-pie' && <HalfBarChart />}
+                </div>
+            </div>
+        )
+    }
 })
 
 export default _default

--- a/src/pages/app/components/Dashboard/style.sass
+++ b/src/pages/app/components/Dashboard/style.sass
@@ -27,6 +27,15 @@
         display: flex
         flex-direction: column
         gap: 4px
+    .top-visit-container
+        .filter
+            display: flex
+            justify-content: space-between
+            align-items: center
+            margin-top: 10px
+            margin-bottom: 10px
+        .chart-container
+            flex: 1
     .help-us-link
         color: var(--el-text-color-primary)
         text-align: center


### PR DESCRIPTION
### Commits

My modifications are mainly in `Dashboard`, details as follow:

- replace screen-size-sensitive chart with a **manual chart type**
    - now I apply 3 chart types and they are well constructed and readable (like `Habit.Period`)
- use **dynamic** `k` **value** that users can change it to easily see their network usage.

> **PS:** In my personal view, I think it's not that necessary to change chart type according to screen size, so I think that changing it up to users can be better, so do the dynamic `k`. On the other hand, add this `Filter` in `TopKVisit` makes the component more compact. I'm not sure if it contradict with your design. Anyway, the original design is excellent that I can easily comprehend part of them and commit changes. 
 